### PR TITLE
Fixed View Session Link URL

### DIFF
--- a/oshc/main/templates/base.html
+++ b/oshc/main/templates/base.html
@@ -28,7 +28,7 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Sessions <span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
-              <li><a href="https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q/videos/" target="_blank">View Session</a></li>
+              <li><a href="https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q/videos" target="_blank">View Session</a></li>
               <li><a href="{% url 'request_session' %}" target="_blank">Request a Session</a></li>
             </ul>
           </li>


### PR DESCRIPTION
The url for the View Session link was changed from https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q/videos/ to https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q/videos.

<!-- Thank you for submitting this PR. You are awesome!
-->

**Checklist**

- [x] My branch is up-to-date with the upstream `predev` branch.
- [x] I have added necessary documentation (if appropriate).

**Which issue does this PR fix?**: fixes #213

This PR changes the View Session link URL from https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q/videos/ to https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q/videos to close issue #213.

**Why do we need this PR?**:

If relevant, please include a screenshot.

**Demo (optional)**:

Some tips for you to write the instructions:
- Prefer bulleted description
- Start after checking out this branch
- Include any setup required, such as migrating databases, etc.

**Testing instructions:**

If there is any work still left to do, please add it here.

**TODOs (if any)**:

**A picture of a cute animal (not mandatory but encouraged)**:

